### PR TITLE
Adding the bill slug to recent and specific bills

### DIFF
--- a/ProPublicaCongressAPI.Contracts/RecentBill.cs
+++ b/ProPublicaCongressAPI.Contracts/RecentBill.cs
@@ -6,6 +6,8 @@ namespace ProPublicaCongressAPI.Contracts
     {
         public string BillId { get; set; }
 
+        public string BillSlug { get; set; }
+
         public string BillType { get; set; }
 
         public string BillNumber { get; set; }

--- a/ProPublicaCongressAPI.Contracts/SpecificBill.cs
+++ b/ProPublicaCongressAPI.Contracts/SpecificBill.cs
@@ -6,6 +6,7 @@ namespace ProPublicaCongressAPI.Contracts
     public class SpecificBill
     {
         public string BillId { get; set; }
+        public string BillSlug { get; set; }
         public int Congress { get; set; }
         public string BillNumber { get; set; }
         public string BillType { get; set; }

--- a/ProPublicaCongressAPI/InternalModels/RecentBill.cs
+++ b/ProPublicaCongressAPI/InternalModels/RecentBill.cs
@@ -7,6 +7,9 @@ namespace ProPublicaCongressAPI.InternalModels
         [JsonProperty("bill_id")]
         public string BillId { get; set; }
 
+        [JsonProperty("bill_slug")]
+        public string BillSlug { get; set; }
+
         [JsonProperty("bill_type")]
         public string BillType { get; set; }
 

--- a/ProPublicaCongressAPI/InternalModels/SpecificBill.cs
+++ b/ProPublicaCongressAPI/InternalModels/SpecificBill.cs
@@ -8,6 +8,9 @@ namespace ProPublicaCongressAPI.InternalModels
         [JsonProperty("bill_id")]
         public string BillId { get; set; }
 
+        [JsonProperty("bill_slug")]
+        public string BillSlug { get; set; }
+
         [JsonProperty("datetime")]
         public int Congress { get; set; }
 


### PR DESCRIPTION
This bill slug is important because it is what you need to pass to the GetSpecificBill api.  The haven't documented it yet but it shows up in the response:

![image](https://user-images.githubusercontent.com/438824/28995622-a4f666da-79bb-11e7-94a1-9c05a3883f64.png)
